### PR TITLE
Add alloc to no_std sysroots

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,11 +189,14 @@ impl Sysroot {
                 r#"
 [dependencies.core]
 path = {src_dir_core:?}
+[dependencies.alloc]
+path = {src_dir_alloc:?}
 [dependencies.compiler_builtins]
 features = ["rustc-dep-of-std", "mem"]
 version = "*"
                 "#,
                 src_dir_core = src_dir.join("core"),
+                src_dir_alloc = src_dir.join("alloc"),
             ),
             SysrootConfig::WithStd { std_features } => format!(
                 r#"


### PR DESCRIPTION
This makes `alloc` available for `no_std` applications for targets like `x86_64-unknown-none` (`MIRI_NO_STD=1`, `MIRI_TEST_TARGET=x86_64-unknown-none`).