### PR TITLE
reorganize SysrootConfig and feature handling

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -89,7 +89,7 @@ fn no_std() {
     build_sysroot(
         SysrootBuilder::new(sysroot_dir.path(), "thumbv7em-none-eabihf")
             .build_mode(BuildMode::Check)
-            .sysroot_config(SysrootConfig::NoStd),
+            .sysroot_config(SysrootConfig::Alloc),
     );
 }
 
@@ -130,6 +130,6 @@ fn json_target() {
     build_sysroot(
         SysrootBuilder::new(sysroot_dir.path(), &target_file)
             .build_mode(BuildMode::Check)
-            .sysroot_config(SysrootConfig::NoStd),
+            .sysroot_config(SysrootConfig::Alloc),
     );
 }


### PR DESCRIPTION
Turns out that the sysroot 'root' crate forwards features to std, so we can just say that SysrootConfig determines the root crate and features apply to that crate and the rest must be handled on the sysroot side.

In particular we no longer set any default features for `alloc`. The old default corresponds to adding the `compiler_builtins/mem` feature.