### PR TITLE
Use our own release profile to insulate from custom release profiles

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,9 +351,8 @@ version = "0.0.0"
 path = "lib.rs"
 
 [profile.{DEFAULT_SYSROOT_PROFILE}]
-# While it says "inherits", we override all settings.
-# This is to insulate us from any custom release profile.
-# The only reason we use inherits is because it's required.
+# We inherit from the local release profile, but then overwrite some
+# settings to ensure we still get a working sysroot.
 inherits = "release"
 panic = 'unwind'
 


### PR DESCRIPTION
Ok this should actually fix the issue with rust-lang/miri#3313 in a nice way. 

It also allows people to override the profile, since profiles are at the lowest precedence. So if someone wants to build a sysroot with `-Cdebug-assertions=true` they still can and it will override the profile.