### PR TITLE
copying extra files should not be needed any more

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         rust:
           - nightly
           # Check a ~3 months old nightly as "oldest supported version"
-          - nightly-2023-10-01
+          - nightly-2024-01-01
         # We want to run all of the above on Linux, macOS, windows-msvc, windows-gnu.
         # The semantics of combining `include` with other things in GHA are very strange
         # so this seems like the best way of doing that.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -553,28 +553,6 @@ panic = 'unwind'
             fs::copy(&entry, staging_lib_dir.join(entry.file_name().unwrap()))
                 .context("failed to copy cargo out file")?;
         }
-        // If we are doing a full build, copy any other files and directories that need copying from
-        // the original sysroot.
-        if matches!(self.mode, BuildMode::Build) {
-            let extra_copy_paths = &["bin"];
-            let dist_sysroot_target_dir = dist_sysroot()?
-                .join("lib")
-                .join("rustlib")
-                .join(&target_name);
-            for path in extra_copy_paths {
-                let src = dist_sysroot_target_dir.join(path);
-                if src.exists() {
-                    let dst = staging_dir.path().join(path);
-                    symlink_or_copy_dir(&src, &dst).with_context(|| {
-                        format!(
-                            "failed to symlink/copy `{src}` to `{dst}`",
-                            src = src.display(),
-                            dst = dst.display(),
-                        )
-                    })?;
-                }
-            }
-        }
 
         // Write the hash file (into the staging dir).
         fs::write(


### PR DESCRIPTION
With https://github.com/rust-lang/rust/issues/125246 being fixed, we shouldn't have to copy the linker to the new sysroot any more. (That anyway didn't work properly for cross-builds.)