### PR TITLE
Use the `patches` table from the workspace manifest if possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +19,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -58,6 +55,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,48 +95,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
 name = "rustc-build-sysroot"
 version = "0.5.8"
 dependencies = [
  "anyhow",
- "regex",
  "rustc_version",
  "tempfile",
+ "toml",
  "walkdir",
 ]
 
@@ -165,6 +167,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +218,54 @@ dependencies = [
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "walkdir"
@@ -277,6 +367,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ tempfile = "3"
 rustc_version = "0.4"
 anyhow = "1.0"
 walkdir = "2.4"
-regex = "1.11.1"
+toml = { version = "0.8.23", features = ["preserve_order"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,24 +303,24 @@ impl<'a> SysrootBuilder<'a> {
         let crates = match &self.config {
             SysrootConfig::NoStd => format!(
                 r#"
-[dependencies.core]
-path = {src_dir_core:?}
-[dependencies.alloc]
-path = {src_dir_alloc:?}
-[dependencies.compiler_builtins]
-features = ["rustc-dep-of-std", "mem"]
-version = "*"
+                [dependencies.core]
+                path = {src_dir_core:?}
+                [dependencies.alloc]
+                path = {src_dir_alloc:?}
+                [dependencies.compiler_builtins]
+                features = ["rustc-dep-of-std", "mem"]
+                version = "*"
                 "#,
                 src_dir_core = src_dir.join("core"),
                 src_dir_alloc = src_dir.join("alloc"),
             ),
             SysrootConfig::WithStd { std_features } if have_sysroot_crate => format!(
                 r#"
-[dependencies.std]
-features = {std_features:?}
-path = {src_dir_std:?}
-[dependencies.sysroot]
-path = {src_dir_sysroot:?}
+                [dependencies.std]
+                features = {std_features:?}
+                path = {src_dir_std:?}
+                [dependencies.sysroot]
+                path = {src_dir_sysroot:?}
                 "#,
                 std_features = std_features,
                 src_dir_std = src_dir.join("std"),
@@ -329,11 +329,11 @@ path = {src_dir_sysroot:?}
             // Fallback for old rustc where the main crate was `test`, not `sysroot`
             SysrootConfig::WithStd { std_features } => format!(
                 r#"
-[dependencies.std]
-features = {std_features:?}
-path = {src_dir_std:?}
-[dependencies.test]
-path = {src_dir_test:?}
+                [dependencies.std]
+                features = {std_features:?}
+                path = {src_dir_std:?}
+                [dependencies.test]
+                path = {src_dir_test:?}
                 "#,
                 std_features = std_features,
                 src_dir_std = src_dir.join("std"),
@@ -346,9 +346,9 @@ path = {src_dir_test:?}
         let builtins_patch = if let Some(path) = builtins_patch_location(src_dir) {
             format!(
                 r#"
-[patch.crates-io.compiler_builtins]
-path = {src_dir_workspace_builtins:?}
-            "#,
+                [patch.crates-io.compiler_builtins]
+                path = {src_dir_workspace_builtins:?}
+                "#,
                 src_dir_workspace_builtins = src_dir.join(path),
             )
         } else {
@@ -364,21 +364,21 @@ path = {src_dir_workspace_builtins:?}
         let patches = match &self.config {
             SysrootConfig::NoStd => format!(
                 r#"
-[patch.crates-io.rustc-std-workspace-core]
-path = {src_dir_workspace_core:?}
-{builtins_patch}
+                [patch.crates-io.rustc-std-workspace-core]
+                path = {src_dir_workspace_core:?}
+                {builtins_patch}
                 "#,
                 src_dir_workspace_core = src_dir.join("rustc-std-workspace-core"),
             ),
             SysrootConfig::WithStd { .. } => format!(
                 r#"
-[patch.crates-io.rustc-std-workspace-core]
-path = {src_dir_workspace_core:?}
-[patch.crates-io.rustc-std-workspace-alloc]
-path = {src_dir_workspace_alloc:?}
-[patch.crates-io.rustc-std-workspace-std]
-path = {src_dir_workspace_std:?}
-{builtins_patch}
+                [patch.crates-io.rustc-std-workspace-core]
+                path = {src_dir_workspace_core:?}
+                [patch.crates-io.rustc-std-workspace-alloc]
+                path = {src_dir_workspace_alloc:?}
+                [patch.crates-io.rustc-std-workspace-std]
+                path = {src_dir_workspace_std:?}
+                {builtins_patch}
                 "#,
                 src_dir_workspace_core = src_dir.join("rustc-std-workspace-core"),
                 src_dir_workspace_alloc = src_dir.join("rustc-std-workspace-alloc"),
@@ -388,25 +388,25 @@ path = {src_dir_workspace_std:?}
 
         format!(
             r#"
-[package]
-authors = ["rustc-build-sysroot"]
-name = "custom-local-sysroot"
-version = "0.0.0"
-edition = "2018"
+            [package]
+            authors = ["rustc-build-sysroot"]
+            name = "custom-local-sysroot"
+            version = "0.0.0"
+            edition = "2018"
 
-[lib]
-# empty dummy, just so that things are being built
-path = "lib.rs"
+            [lib]
+            # empty dummy, just so that things are being built
+            path = "lib.rs"
 
-[profile.{DEFAULT_SYSROOT_PROFILE}]
-# We inherit from the local release profile, but then overwrite some
-# settings to ensure we still get a working sysroot.
-inherits = "release"
-panic = 'unwind'
+            [profile.{DEFAULT_SYSROOT_PROFILE}]
+            # We inherit from the local release profile, but then overwrite some
+            # settings to ensure we still get a working sysroot.
+            inherits = "release"
+            panic = 'unwind'
 
-{crates}
+            {crates}
 
-{patches}
+            {patches}
             "#
         )
     }


### PR DESCRIPTION
Remove special casing for the `compiler-builtins` patch by instead picking up the `patch` table from the workspace `Cargo.toml`. Paths in the patch table are remapped to be relative to the source directory, which matches current behavior.