### PR TITLE
remove handling for old compiler-builtins versions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,25 +299,7 @@ impl<'a> SysrootBuilder<'a> {
 
     /// Generate the contents of the manifest file for the sysroot build.
     fn gen_manifest(&self, src_dir: &Path) -> String {
-        let have_builtins_crate = src_dir.join("compiler-builtins").exists();
         let crates = match &self.config {
-            // As long as the sysroot has a patch for compiler_builtins, we need to include it in the
-            // NoStd variant explicitly.
-            SysrootConfig::NoStd if have_builtins_crate => format!(
-                r#"
-                [dependencies.core]
-                path = {src_dir_core:?}
-                [dependencies.alloc]
-                path = {src_dir_alloc:?}
-                [dependencies.compiler_builtins]
-                path = {src_dir_builtins:?}
-                features = ["rustc-dep-of-std", "mem"]
-                "#,
-                src_dir_core = src_dir.join("core"),
-                src_dir_alloc = src_dir.join("alloc"),
-                src_dir_builtins = src_dir.join("compiler-builtins").join("compiler-builtins"),
-            ),
-            // Fallback for old rust without in-tree `compiler-builtins`.
             SysrootConfig::NoStd => format!(
                 r#"
                 [dependencies.core]
@@ -325,11 +307,12 @@ impl<'a> SysrootBuilder<'a> {
                 [dependencies.alloc]
                 path = {src_dir_alloc:?}
                 [dependencies.compiler_builtins]
-                version = "*"
-                features = ["rustc-dep-of-std", "mem"]
+                path = {src_dir_builtins:?}
+                features = ["compiler-builtins", "mem"]
                 "#,
                 src_dir_core = src_dir.join("core"),
                 src_dir_alloc = src_dir.join("alloc"),
+                src_dir_builtins = src_dir.join("compiler-builtins").join("compiler-builtins"),
             ),
             SysrootConfig::WithStd { std_features } => format!(
                 r#"


### PR DESCRIPTION
It should not be needed any more.